### PR TITLE
CRLF fix for non-Unix systems

### DIFF
--- a/proxy/proxy.Dockerfile
+++ b/proxy/proxy.Dockerfile
@@ -4,4 +4,7 @@ RUN apk add --no-cache openssl
 RUN mkdir /cert
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY 01-generate-certs.sh /docker-entrypoint.d
-RUN chmod +x /docker-entrypoint.d/01-generate-certs.sh
+RUN touch /docker-entrypoint.d/02-generate-certs.sh
+RUN dos2unix /docker-entrypoint.d/01-generate-certs.sh /docker-entrypoint.d/02-generate-certs.sh
+RUN rm /docker-entrypoint.d/01-generate-certs.sh
+RUN chmod +x /docker-entrypoint.d/02-generate-certs.sh


### PR DESCRIPTION
Fixes an issue where the `proxy` service fails to start on non-Unix systems that use the CRLF line endings.