### PR TITLE
Switch from MySQL to PostgreSQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mysql:
-        image: mysql:8.0.27
+        image: postgres:13.5-alpine
         env:
-          MYSQL_ROOT_PASSWORD: virtudoc
-          MYSQL_DATABASE: virtudoc
-        ports: [ '3306:3306' ]
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: virtudoc
+          POSTGRES_DB: virtudoc
+        ports: [ '5432:5432' ]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -35,7 +36,7 @@ jobs:
       - name: Run JUnit tests
         run: mvn test -B -T1
         env:
-          JDBC_DATABASE_URL: jdbc:mysql://localhost:3306/virtudoc?user=root&password=virtudoc
+          JDBC_DATABASE_URL: jdbc:postgresql://localhost:5432/virtudoc
           JDBC_DATABASE_USERNAME: root
           JDBC_DATABASE_PASSWORD: virtudoc
       - name: Check slug size

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,19 +12,25 @@ services:
     volumes:
     - ./:/app
     environment:
-      JDBC_DATABASE_URL: jdbc:mysql://db:3306/virtudoc?user=root&password=virtudoc
+      JDBC_DATABASE_URL: jdbc:postgresql://db:5432/virtudoc
       JDBC_DATABASE_USERNAME: root
       JDBC_DATABASE_PASSWORD: virtudoc
   db:
-    image: mysql:8.0.27
+    image: postgres:13.5-alpine
     ports:
-      - "33306:3306"
+      - "55432:5432"
     volumes:
       - dbdata:/var/lib/mysql
     restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-q", "-d", "postgres", "-U", "root" ]
+      timeout: 30s
+      interval: 10s
+      retries: 10
     environment:
-      MYSQL_ROOT_PASSWORD: virtudoc
-      MYSQL_DATABASE: virtudoc
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: virtudoc
+      POSTGRES_DB: virtudoc
   proxy:
     build:
       context: ./proxy

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,6 +1,6 @@
 setup:
   addons:
-    - plan: jawsdb:kitefin
+    - plan: heroku-postgresql:hobby-dev
 build:
   docker:
     web: prod.Dockerfile

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,8 +29,11 @@ spring:
     url: ${JDBC_DATABASE_URL}
     username: ${JDBC_DATABASE_USERNAME}
     password: ${JDBC_DATABASE_PASSWORD}
-    driverClassName: com.mysql.jdbc.Driver
+    driverClassName: org.postgresql.Driver
   jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
@@ -50,8 +53,11 @@ spring:
     url: ${JDBC_DATABASE_URL}
     username: ${JDBC_DATABASE_USERNAME}
     password: ${JDBC_DATABASE_PASSWORD}
-    driverClassName: com.mysql.jdbc.Driver
+    driverClassName: org.postgresql.Driver
   jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     show-sql: true
@@ -68,8 +74,11 @@ spring:
     url: ${JDBC_DATABASE_URL}
     username: ${JDBC_DATABASE_USERNAME}
     password: ${JDBC_DATABASE_PASSWORD}
-    driverClassName: com.mysql.jdbc.Driver
+    driverClassName: org.postgresql.Driver
   jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     database: mysql


### PR DESCRIPTION
# Summary
- Added Postgres containers in dev and test environments.
- Changed environment configuration for dev and test profiles to use Postgres connection string.
- Removed all references to MySQL JDBC component.
- Removed MySQL container in dev and test environments.

Closes #18

# How to Test
- Verify the JUnit tests pass on GHA with a bot comment below (assumes that the SampleEntity class has not been deleted).
- Run the entire stack locally and confirm that both `/` and `/sampleentity/all` load in your browser without errors.
- With the local dev stack running, connect to the Postgres instance `localhost:55432/virtudoc`. Username is still `root` and password is `virtudoc`.

# Additional Comments
See #2 for why this change was necessary.