### PR TITLE
Fix broken mvnw script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM openjdk:11.0.13-jdk-bullseye
-
+RUN apt-get update
+RUN apt-get install dos2unix -y
+WORKDIR /
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN touch /docker-entrypoint.sh
+RUN dos2unix /entrypoint.sh /docker-entrypoint.sh
+RUN rm /entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 RUN mkdir /app
 WORKDIR /app
-CMD ["./mvnw", "spring-boot:run", "-Dspring-boot.run.arguments=--spring.profiles.active=dev-managed"]
+CMD ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+dos2unix ./mvnw ./mvnw
+chmod +x ./mvnw
+./mvnw spring-boot:run -Dspring-boot.run.arguments=--spring.profiles.active=dev-managed


### PR DESCRIPTION
# Summary
- Fixed issue where Docker Compose wouldn't start if certain scripts were modified on Windows or stored on an NTFS file system.

Closes #40 

# How to Test
- Run `docker-compose up --build` and verify that the `web` container starts and does not terminate with error code 127.

# Additional Comments
This is a stupid fix. I know this is a stupid fix. I am not proud of this fix. Please feel free to suggest a better solution if you know of one. No, `chmod` doesn't work, and neither does messing with the NTFS file security header. As far as I can tell, using native Maven instead of mvnw does some weird stuff with dependencies that breaks a lot of optimizations in the dev image.

I'm working on a regression test so that bugs like this can get caught before a PR merge. It's complicated enough that it needs its own PR.