### PR TITLE
Fixed Web container crash on boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM openjdk:11.0.13-jdk-bullseye
 RUN apt-get update
 RUN apt-get install dos2unix -y
 WORKDIR /
-COPY docker-entrypoint.sh /entrypoint.sh
-RUN touch /docker-entrypoint.sh
-RUN dos2unix /entrypoint.sh /docker-entrypoint.sh
-RUN rm /entrypoint.sh
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN dos2unix -o /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 RUN mkdir /app
 WORKDIR /app

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
-dos2unix ./mvnw ./mvnw
+dos2unix -o ./mvnw
 chmod +x ./mvnw
 ./mvnw spring-boot:run -Dspring-boot.run.arguments=--spring.profiles.active=dev-managed


### PR DESCRIPTION
# Summary
- Changed `docker-entrypoint.sh` to use `/bin/sh` instead of `/bin/bash` (don't ask why this works, we're using a freaking fat image of Debian).
- Changed `dos2unix` to use less dumb flags.

Closes #50

# How to Test
Download branch locally and bring up your web stack with `docker-compose up --build`. If errors persist, delete the images from your local image store inside the Docker Desktop program (or using the `docker` CLI).

# Additional Comments
Production image does not need these fixes because the production image does not (yet) use an entrypoint script.