### PR TITLE
Tag Images in Dev Stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   web:
+    image: virtudoc/web
     build:
       context: .
       dockerfile: Dockerfile
@@ -37,6 +38,7 @@ services:
       POSTGRES_PASSWORD: virtudoc
       POSTGRES_DB: virtudoc
   proxy:
+    image: virtudoc/proxy
     build:
       context: ./proxy
       dockerfile: proxy.Dockerfile


### PR DESCRIPTION
# Summary
- Added `virtudoc/web` as image name for web container.
- Added `virtudoc/proxy` as image name for proxy container.

Closes #52

# How to Test
- Clone branch locally and start dev stack. In Docker Desktop on the images page you should see two images with the above names marked as "in use". The Compose stack should no longer use random hashes as the names for images we create.

# Remarks
Although creating a new image in the Images tab of Docker Desktop doesn't actually use extra disk space, it does make it difficult to hunt down a specific image that needs to be deleted when you are running into caching-related problems with the underlying Docker Engine.