### PR TITLE
Automatic Version Bumping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/proxy"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5

--- a/pom.xml
+++ b/pom.xml
@@ -20,39 +20,47 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.restdocs</groupId>
 			<artifactId>spring-restdocs-mockmvc</artifactId>
 			<scope>test</scope>
+			<version>2.0.5.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
+			<version>42.3.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
+			<version>1.4.200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 			<scope>test</scope>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.mail</groupId>
@@ -62,6 +70,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context-support</artifactId>
+			<version>5.3.14</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -72,10 +81,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>jakarta.mail</artifactId>
+			<version>1.6.7</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
@@ -95,6 +106,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+			<version>2.6.2</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
# Summary
- Added pinned version numbers to dependencies added by Spring Initializr.
- Added Dependabot configuration for automatic PRs and tests of new version.

Related to #63, but does not close it. Pending completion of #43.

# How to Test
-Verify that the GitHub Dependabot configuration validation check passes below in the PR checks section.

# Comments
This PR will allow for GitHub Dependabot to automatically create pull requests whenever there are new versions of dependencies that we use. Tests will automatically be performed and let us know the compatibility level of the new version. These PRs should still undergo human review, but as long as we are writing good unit/system tests this should be a mostly automated process.