### PR TITLE
Primitive database seeding

### DIFF
--- a/src/main/java/com/virtudoc/web/runner/DatabaseSeedRunner.java
+++ b/src/main/java/com/virtudoc/web/runner/DatabaseSeedRunner.java
@@ -1,0 +1,62 @@
+package com.virtudoc.web.runner;
+
+import com.virtudoc.web.dto.NewUserDTO;
+import com.virtudoc.web.entity.Appointment;
+import com.virtudoc.web.entity.UserAccount;
+import com.virtudoc.web.repository.AppointmentRepository;
+import com.virtudoc.web.repository.RoleRepository;
+import com.virtudoc.web.repository.SampleEntityRepository;
+import com.virtudoc.web.service.AuthenticationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Primitive database seeding tool that runs on application boot. Will only run if the database is empty, and if the
+ * current application profile is 'dev-managed' (e.g. inside of Docker Compose). This is an MVP of this feature,
+ * so for now just add your repositories and manually add your data below. More enhancements are coming in the future
+ * including reading from YAML configuration and @annotations on repository classes.
+ *
+ * @author ARMmaster17
+ */
+@Component
+@Profile("dev-managed")
+@Order(value=1)
+public class DatabaseSeedRunner implements CommandLineRunner {
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private AppointmentRepository appointmentRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private SampleEntityRepository sampleEntityRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        //region Roles
+
+        //endregion
+
+        //region User Accounts
+        // If you need more granular control over fields in the UserAccount object, use the DTO constructor instead.
+        authenticationService.RegisterNewAccount(new UserAccount("doctor1", "virtudoc", "DOCTOR"));
+        authenticationService.RegisterNewAccount(new UserAccount("admin1", "virtudoc", "ADMIN"));
+        authenticationService.RegisterNewAccount(new UserAccount("patient1", "virtudoc", "PATIENT"));
+        //endregion
+
+        //region Appointments
+
+        //endregion
+
+        //region SampleEntities
+
+        //endregion
+    }
+}


### PR DESCRIPTION
# Summary
Very simple seeding runner that adds hard-coded values to the database on application boot if certain conditions are met. Only runs with the `dev-managed` profile (e.g. inside of Docker Compose) to ensure that inserted data does not affect JUnit tests or that hard-coded credentials do not appear in production (HIPAA-compliance).

Closes #84

# How to Test
- Verify that all JUnit tests below pass (existing tests already cover multi-profile database integrity checks.
- Run the dev stack locally and verify that three user accounts are inserted into the database on application boot.

# Comments
This is just something really primitive that I wanted to get out the door so everyone can start using it. In the future I plan to make it load data from a YAML file, and new repositories created in the future will automatically be supported without having to hard-code the repository/entity pair into the runner.

To add your data to the runner, edit `src/main/java/com/virtudoc/web/runner/DatabaseSeedRunner.java` and add your data inside the correct comment region. Please note that this runner should only be used for manual testing with the Docker Compose stack. Unit tests should still manage their own testing data. This runner should not be used for production data either, as production credentials and other sensitive data should never be hard-coded in plaintext.