### PR TITLE
Javadoc on GitHub Pages

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,25 @@
+name: Javadoc
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  javadoc-push:
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Setup Java 11 JDK
+        uses: actions/setup-java@v2
+          with:
+            distribution: 'adopt'
+            java-package: jdk
+            java-version: 11
+      - name: Generate Javadocs
+        run: mvn javadoc:javadoc -B -Dmaven.test.skip=true -T4 -q
+      - name: Upload Javadocs
+        if: github.ref == 'refs/heads/main' # Only deploy on push
+        uses: JamesIves/github-pages-deploy-action@v4.2.3
+          with:
+            branch: gh-pages
+            folder: ./target/site/apidocs

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,15 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
# Summary
- Added Javadoc plugin (run with `./mvnw javadoc:javadoc`)
- Added GHA pipeline job to push to `gh-pages` branch.

Closes #47

# How to Test
- Run `./mvnw javadoc:javadoc` locally and verify that the documentation is generated in `./target/site/apidocs/`.
- Once this PR is merged, verify that the documentation website is visible at https://virtudoc.github.io/cs4850group5a.