### PR TITLE
Fixed YAML validation errors

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -6,20 +6,21 @@ on:
     branches: [ main ]
 jobs:
   javadoc-push:
+    runs-on: "ubuntu-latest"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Setup Java 11 JDK
         uses: actions/setup-java@v2
-          with:
-            distribution: 'adopt'
-            java-package: jdk
-            java-version: 11
+        with:
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: 11
       - name: Generate Javadocs
         run: mvn javadoc:javadoc -B -Dmaven.test.skip=true -T4 -q
       - name: Upload Javadocs
         if: github.ref == 'refs/heads/main' # Only deploy on push
         uses: JamesIves/github-pages-deploy-action@v4.2.3
-          with:
-            branch: gh-pages
-            folder: ./target/site/apidocs
+        with:
+          branch: gh-pages
+          folder: ./target/site/apidocs


### PR DESCRIPTION
# Summary
- Fixed YAML issues in GitHub Actions manifest.

Related to #47 

# How to Test
- Verify that a job named `Javadoc` appears below, and it does NOT link to the unit test results pipeline page.

# Comments
For some reason, GHA didn't complain during the PR, only on push. Need to investigate why that happened.