### PR TITLE
CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+###########
+# DEVOPS ##
+###########
+# TODO: If at least one other person wants to help with devops reviews, I'll swap this to use the @CS4850Group5A/DevOps team instead.
+## Docker files
+docker-compose.yml     @ARMmaster17
+Dockefile              @ARMmaster17
+prod.Dockerfile        @ARMmaster17
+proxy/proxy.Dockerfile @ARMmaster17
+## Github Actions
+.github/workflows/*    @ARMmaster17
+
+# Add more entries here...


### PR DESCRIPTION
# Summary
- Added CODEOWNERS file
- Added ownership of Docker manifests to devops team (@ARMmaster17 for right now, will switch to team if someone else wants to join).

# How to Test
- After PR is merged, make a change to any file that matches a line in CODEOWNERS and submit a PR. The person/team mentioned in the CODEOWNERS file should automatically be added as a PR reviewer.

# Comments
Issue #89 is marked as a proposal for discussion, and I want it to continue to be a discussion until a team-wide consensus is reached. My objective with this PR is two-fold:
1. I want to safely enable automatic merges from Dependabot, but I want to make sure that I'm in the loop if changes are made to Docker manifests as those need to be manually tested locally with a special config before approving, even if all the tests pass.
2. I want to have this file present so that if anyone wishes to implement the ideas in #89, the file is already there with sample lines so that it is straightforward how to add what you need.

As a separate item, I marked myself as the sole reviewer for these files because if I created a team with just me, and I made changes to these files, I would be unable to merge. The devops team would get marked as a required reviewer, and I can't approve my own PR. If I specify myself in the CODEOWNERS file, I will not be marked for review if I am the PR author. If anyone wants to join me in testing and approving devops PRs, create a team within our org on GitHub and I'll swap to the team identifier in the CODEOWNERS file.