### PR TITLE
Container Healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 
 services:
   web:
@@ -28,6 +28,12 @@ services:
       AWS_SECRET_ACCESS_KEY: virtudoc
       AWS_BUCKET: virtudoc
       AWS_ENDPOINT: http://minio:9000
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "--head", "--write-out", "%{http_code}", "http://localhost:8080"]
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
   db:
     image: postgres:13.5-alpine
     ports:

--- a/src/main/java/com/virtudoc/web/controller/DebugController.java
+++ b/src/main/java/com/virtudoc/web/controller/DebugController.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * reset the app in the event of a soft Spring-layer crash.
  */
 @Controller
-@Profile(value={"dev-managed"})
+@Profile("!prod")
 @RequestMapping(path="/debug")
 public class DebugController {
     @GetMapping("/health")

--- a/src/test/java/com/virtudoc/web/HealthEndpointTests.java
+++ b/src/test/java/com/virtudoc/web/HealthEndpointTests.java
@@ -1,0 +1,22 @@
+package com.virtudoc.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HealthEndpointTests {
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void testHealthEndpoint() throws Exception {
+        String body = this.restTemplate.getForObject("http://localhost:" + port + "/debug/health", String.class);
+        assert(body.equals("{\"health\":\"OK\"}"));
+    }
+}


### PR DESCRIPTION
# Summary
- Added healthcheck block to `web` container manifest in dev stack.
- Added tests around status endpoint.
- Changed status endpoint controller to run in all environments except for production (Heroku provides their own healthcheck system that does not need a JSON REST endpoint).
- Changed the dev stack manifest to require Docker Composer 3.4 or newer.

Closes #124

# How to Test
- Running the dev stack should work normally.
- If there is an issue that breaks the website, but does not crash the server software itself, the container status in Docker Desktop should reflect this and mark the website as down.

# Comments
This change has been added primarily to ensure that bad configuration files and lazy-loaded classes don't invisibly break the application when running on GHA during the `test-stack` tests. If the container is able to start, but requests are not being served properly, this should now show up in the `test-stack` tests.