### PR TITLE
File ownership and ACL blocking

### DIFF
--- a/src/main/java/com/virtudoc/web/entity/FileEntity.java
+++ b/src/main/java/com/virtudoc/web/entity/FileEntity.java
@@ -31,6 +31,9 @@ public class FileEntity {
 
     private Date uploadDate;
 
+    @ManyToOne
+    private UserAccount owner;
+
     /**
      * For use by Hibernate framework serialize. Do not use.
      */
@@ -48,6 +51,20 @@ public class FileEntity {
         this.filePath = filePath;
         this.storageType = storageType;
         this.uploadDate = uploadDate;
+    }
+
+    /**
+     * For internal use inside the FileService class only. Do not use directly.
+     * @param filePath .
+     * @param storageType .
+     * @param uploadDate .
+     * @param owner .
+     */
+    public FileEntity(@NotNull @NotEmpty String filePath, @NotNull @NotEmpty String storageType, Date uploadDate, UserAccount owner) {
+        this.filePath = filePath;
+        this.storageType = storageType;
+        this.uploadDate = uploadDate;
+        this.owner = owner;
     }
 
     /**
@@ -76,5 +93,13 @@ public class FileEntity {
      */
     public Date getUploadDate() {
         return uploadDate;
+    }
+
+    /**
+     * Gets the user account that owns the file.
+     * @return Owner.
+     */
+    public UserAccount getOwner() {
+        return owner;
     }
 }

--- a/src/main/java/com/virtudoc/web/exception/FileAccessNotPermitted.java
+++ b/src/main/java/com/virtudoc/web/exception/FileAccessNotPermitted.java
@@ -1,0 +1,7 @@
+package com.virtudoc.web.exception;
+
+public class FileAccessNotPermitted extends Exception {
+    public FileAccessNotPermitted(String fileName, String accessUser) {
+        super("File " + fileName + " access attempt blocked for user " + accessUser);
+    }
+}

--- a/src/main/java/com/virtudoc/web/service/FileService.java
+++ b/src/main/java/com/virtudoc/web/service/FileService.java
@@ -1,12 +1,16 @@
 package com.virtudoc.web.service;
 
 import com.virtudoc.web.entity.FileEntity;
+import com.virtudoc.web.entity.UserAccount;
+import com.virtudoc.web.exception.FileAccessNotPermitted;
 import com.virtudoc.web.repository.FileRepository;
+import org.apache.catalina.User;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.InputStream;
 import java.util.Date;
 
@@ -15,8 +19,7 @@ import java.util.Date;
  * automatically select the best file storage method depending on what environment the web app is running in. For
  * example, when running JUnit tests outside of Docker Compose, the web app will utilize an ephemeral directory on your
  * computer. In testing and when running in side Docker Compose, FileService will utilize Minio through the S3 API. In
- * production, FileService will use Amazon S3 through a bridge SaaS provider. Note that this service does not perform
- * any kind of user authentication.
+ * production, FileService will use Amazon S3 through a bridge SaaS provider.
  *
  * @author ARMmaster17
  */
@@ -31,31 +34,116 @@ public class FileService {
     @Autowired
     private Logger logger;
 
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    /**
+     * Creates a file from a MIME stream from a user after submitting an HTML form with a file upload function. This
+     * variant of the method will upload the file with public access, meaning that anyone can access the file.
+     *
+     * @param file The file to be uploaded.
+     * @return The file entity that was created.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public FileEntity CreateFile(MultipartFile file) throws Exception {
+        return createFile(file, null);
+    }
+
     /**
      * Creates a file from a MIME stream from a user after submitting an HTML form with a file upload function. Use this
      * method instead of FileRepository.create().
      * @param file MIME stream from the HTML form submission.
+     * @param request HttpServletRequest object from the controller.
      * @return Saved FileEntity entry with file location details.
      * @throws Exception Error with underlying ephemeral or block storage layer.
      */
-    public FileEntity CreateFile(MultipartFile file) throws Exception {
+    public FileEntity CreateFile(MultipartFile file, HttpServletRequest request) throws Exception {
+        UserAccount owner = authenticationService.GetCurrentUser(request);
+        return createFile(file, owner);
+    }
+
+    /**
+     * Creates a file from a MIME stream from a user after submitting an HTML form with a file upload function. Use this
+     * method instead of FileRepository.create().
+     * @param file MIME stream from the HTML form submission.
+     * @param owner UserAccount object of the user who owns the file.
+     * @return Saved FileEntity entry with file location details.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public FileEntity CreateFile(MultipartFile file, UserAccount owner) throws Exception {
+        return createFile(file, owner);
+    }
+
+    /**
+     * Internal method for creating a file in the persistent file storage layer. Do not use this method directly.
+     * @param file MIME stream from the HTML form submission.
+     * @param owner UserAccount object of the user who owns the file.
+     * @return Saved FileEntity entry with file location details.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    private FileEntity createFile(MultipartFile file, UserAccount owner) throws Exception {
         String filePath = blockStorageInterface.PutFile(file);
-        FileEntity newFile = new FileEntity(filePath, blockStorageInterface.GetStorageId(), new Date());
+        FileEntity newFile = new FileEntity(filePath, blockStorageInterface.GetStorageId(), new Date(), owner);
         fileRepository.save(newFile);
-        // TODO: This should have the actual user ID once authentication/ACL/RBA is fully implemented.
-        logger.info("AUDIT: User uploaded file {} to {} storage", filePath, blockStorageInterface.GetStorageId());
+        logger.info("AUDIT: User {} uploaded file {} to {} storage", owner.getUsername(), filePath, blockStorageInterface.GetStorageId());
         return newFile;
     }
 
     /**
-     * Gets the contents of the specified file from the underlying ephemeral or block storage layer. For an example of
+     * Gets the contents of the specified public file from the underlying ephemeral or block storage layer. For an example of
      * how to use the output of this function in a controller, see this answer on StackOverflow:
      * https://stackoverflow.com/a/5673356 Don't forget to close the stream when you are done!
      * @param file File contents to retrieve.
      * @return Stream that can be sent directly to client in response, or redirected to another storage system.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
      */
     public InputStream GetFile(FileEntity file) throws Exception {
+        logger.info("AUDIT: User accessed public file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
+        if (file.getOwner() == null) {
+            throw new FileAccessNotPermitted(file.getFilePath(), "PUBLIC");
+        }
+        return getFile(file);
+    }
+
+    /**
+     * Gets the contents of the specified file from the underlying ephemeral or block storage layer if the user has the
+     * proper permissions. For an example of how to use the output of this function in a controller, see this answer on
+     * StackOverflow: https://stackoverflow.com/a/5673356 Don't forget to close the stream when you are done!
+     * @param file File contents to retrieve.
+     * @param request HttpServletRequest object from the controller.
+     * @return Stream that can be sent directly to client in response, or redirected to another storage system.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public InputStream GetFile(FileEntity file, HttpServletRequest request) throws Exception {
+        UserAccount accessUser = authenticationService.GetCurrentUser(request);
+        return GetFile(file, accessUser);
+    }
+
+    /**
+     * Gets the contents of the specified file from the underlying ephemeral or block storage layer if the user has the
+     * proper permissions. For an example of how to use the output of this function in a controller, see this answer on
+     * StackOverflow: https://stackoverflow.com/a/5673356 Don't forget to close the stream when you are done!
+     * @param file File contents to retrieve.
+     * @param accessUser UserAccount object of the user who is attempting to access the file.
+     * @return Stream that can be sent directly to client in response, or redirected to another storage system.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public InputStream GetFile(FileEntity file, UserAccount accessUser) throws Exception {
         logger.info("AUDIT: User accessed file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
+        if (file.getOwner() == null || file.getOwner().equals(accessUser)) { // TODO: Use complex ACL check for doctors.
+            return getFile(file);
+        }
+        throw new FileAccessNotPermitted(file.getFilePath(), accessUser.getUsername());
+    }
+
+    /**
+     * Raw access method to get the contents of a file. Performs no checks on the user's permissions. Do not use this
+     * method directly.
+     * @param file File contents to retrieve.
+     * @return Stream that can be sent directly to client in response, or redirected to another storage system.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    private InputStream getFile(FileEntity file) throws Exception {
         return blockStorageInterface.GetFile(file.getFilePath());
     }
 
@@ -65,9 +153,47 @@ public class FileService {
      * @param file File to delete.
      */
     public void DeleteFile(FileEntity file) throws Exception {
+        if (file.getOwner() != null) {
+            throw new FileAccessNotPermitted(file.getFilePath(), "PUBLIC");
+        }
+        logger.info("AUDIT: User deleted file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
+        deleteFile(file);
+    }
+
+    /**
+     * Deletes a file entry, and the corresponding file data from block storage.
+     * @param file File to delete.
+     * @param request HttpServletRequest object from the controller.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public void DeleteFile(FileEntity file, HttpServletRequest request) throws Exception {
+        UserAccount accessUser = authenticationService.GetCurrentUser(request);
+        DeleteFile(file, accessUser);
+    }
+
+    /**
+     * Deletes a file entry, and the corresponding file data from block storage.
+     * @param file File to delete.
+     * @param accessUser UserAccount object of the user who is attempting to delete the file.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public void DeleteFile(FileEntity file, UserAccount accessUser) throws Exception {
+        if (file.getOwner() == null || file.getOwner().equals(accessUser)) {
+            logger.info("AUDIT: User {} deleted file {} from {} storage", accessUser.getUsername(), file.getFilePath(), blockStorageInterface.GetStorageId());
+            deleteFile(file);
+        }
+        throw new FileAccessNotPermitted(file.getFilePath(), accessUser.getUsername());
+    }
+
+    /**
+     * Raw access method to delete a file. Performs no checks on the user's permissions. Do not use this method directly
+     * except for JUnit test cleanup operations.
+     * @param file File to delete.
+     * @throws Exception Error with underlying ephemeral or block storage layer.
+     */
+    public void deleteFile(FileEntity file) throws Exception {
         blockStorageInterface.DeleteFile(file.getFilePath());
         fileRepository.delete(file);
-        logger.info("AUDIT: User deleted file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
     }
 
     /**

--- a/src/main/java/com/virtudoc/web/service/FileService.java
+++ b/src/main/java/com/virtudoc/web/service/FileService.java
@@ -100,9 +100,9 @@ public class FileService {
     public InputStream GetFile(FileEntity file) throws Exception {
         logger.info("AUDIT: User accessed public file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
         if (file.getOwner() == null) {
-            throw new FileAccessNotPermitted(file.getFilePath(), "PUBLIC");
+            return getFile(file);
         }
-        return getFile(file);
+        throw new FileAccessNotPermitted(file.getFilePath(), "PUBLIC");
     }
 
     /**
@@ -130,7 +130,7 @@ public class FileService {
      */
     public InputStream GetFile(FileEntity file, UserAccount accessUser) throws Exception {
         logger.info("AUDIT: User accessed file {} from {} storage", file.getFilePath(), blockStorageInterface.GetStorageId());
-        if (file.getOwner() == null || file.getOwner().equals(accessUser)) { // TODO: Use complex ACL check for doctors.
+        if (file.getOwner() == null || file.getOwner().getUsername().equals(accessUser.getUsername())) { // TODO: Use complex ACL check for doctors.
             return getFile(file);
         }
         throw new FileAccessNotPermitted(file.getFilePath(), accessUser.getUsername());

--- a/src/test/java/com/virtudoc/web/FileServiceTest.java
+++ b/src/test/java/com/virtudoc/web/FileServiceTest.java
@@ -68,6 +68,7 @@ public class FileServiceTest {
     @Test
     public void CreatesPublicFile() throws Exception {
         MultipartFile file = new MockMultipartFile("test.txt", "testcontent".getBytes(StandardCharsets.UTF_8));
+        assertNotNull(file);
         FileEntity fileEntry = fileService.CreateFile(file);
         // Check the file entry was saved in the database.
         assertNotEquals(0, fileEntry.getId());
@@ -84,6 +85,7 @@ public class FileServiceTest {
     @Test
     public void ReadPublicFile() throws Exception {
         MultipartFile file = new MockMultipartFile("test.txt", "testcontent".getBytes(StandardCharsets.UTF_8));
+        assertNotNull(file);
         FileEntity fileEntry = fileService.CreateFile(file);
         InputStream contentStream = fileService.GetFile(fileEntry);
         InputStreamReader isr = new InputStreamReader(contentStream, StandardCharsets.UTF_8);

--- a/src/test/java/com/virtudoc/web/FileServiceTest.java
+++ b/src/test/java/com/virtudoc/web/FileServiceTest.java
@@ -97,8 +97,12 @@ public class FileServiceTest {
         MultipartFile file = new MockMultipartFile("test.txt", "testcontent".getBytes(StandardCharsets.UTF_8));
         authenticationService.RegisterNewAccount(new UserAccount("readprivatefile_test1", "none", "PATIENT"));
         UserAccount testUser = userAccountRepository.findByUsername("readprivatefile_test1").get(0); // Reload to get instance with populated ID.
+        assertNotNull(testUser);
         FileEntity fileEntry = fileService.CreateFile(file, testUser);
+        assertNotNull(fileEntry);
+        assertEquals(testUser, fileEntry.getOwner());
         InputStream contentStream = fileService.GetFile(fileEntry, testUser);
+        assertNotNull(contentStream);
         InputStreamReader isr = new InputStreamReader(contentStream, StandardCharsets.UTF_8);
         BufferedReader br = new BufferedReader(isr);
         assertEquals("testcontent", br.readLine());
@@ -110,7 +114,9 @@ public class FileServiceTest {
         MultipartFile file = new MockMultipartFile("test.txt", "testcontent".getBytes(StandardCharsets.UTF_8));
         authenticationService.RegisterNewAccount(new UserAccount("readprivatefile_test1", "none", "PATIENT"));
         UserAccount testUser = userAccountRepository.findByUsername("readprivatefile_test1").get(0); // Reload to get instance with populated ID.
+        assertNotNull(testUser);
         FileEntity fileEntry = fileService.CreateFile(file, testUser);
+        assertNotNull(fileEntry);
         assertThrows(FileAccessNotPermitted.class, () -> fileService.GetFile(fileEntry));
     }
 
@@ -120,8 +126,11 @@ public class FileServiceTest {
         authenticationService.RegisterNewAccount(new UserAccount("readprivatefile_test1", "none", "PATIENT"));
         authenticationService.RegisterNewAccount(new UserAccount("readprivatefile_test2", "none", "PATIENT"));
         UserAccount testUser1 = userAccountRepository.findByUsername("readprivatefile_test1").get(0); // Reload to get instance with populated ID.
+        assertNotNull(testUser1);
         UserAccount testUser2 = userAccountRepository.findByUsername("readprivatefile_test2").get(0); // Reload to get instance with populated ID.
+        assertNotNull(testUser2);
         FileEntity fileEntry = fileService.CreateFile(file, testUser1);
+        assertNotNull(fileEntry);
         assertThrows(FileAccessNotPermitted.class, () -> fileService.GetFile(fileEntry, testUser2));
     }
 }


### PR DESCRIPTION
# Summary
- Added `owner` attribute to `FileEntity` objects.
- Added business logic that only allows for people to read and delete their own files.
- Added business logic for anyone to read and delete public files (i.e. files with no owner).

Closes #148

# How to Test
- Verify that all JUnit tests pass.
- Implement file upload/access in a controller and verify that users can only interact with their own files.

# Comments
Not included in this PR is the logic for doctors to access files uploaded by their patients. This will be addressed in a separate PR as there is some common logic that needs to be shared with other features. Also not included is a file listing using this ACL system.