### PR TITLE
Fixed ApplicationContext failures in bare-metal mode

### DIFF
--- a/src/main/java/com/virtudoc/web/configuration/CloudConfiguration.java
+++ b/src/main/java/com/virtudoc/web/configuration/CloudConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile(value={"prod", "test", "dev-managed"})
 public class CloudConfiguration {
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;

--- a/src/main/java/com/virtudoc/web/entity/Role.java
+++ b/src/main/java/com/virtudoc/web/entity/Role.java
@@ -13,7 +13,7 @@ public class Role {
 
     private String name;
 
-    @ManyToMany(mappedBy = "role")
+    @ManyToMany()
     private Set<UserAccount> users;
 
     public Long getId() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: web
   datasource:
-    url: jdbc:h2:mem:virtudoc
+    url: "jdbc:h2:mem:"
     username: h2user
     password: virtudoc
     driverClassName: org.h2.Driver


### PR DESCRIPTION
# Summary
- Fixed issue where JUnit tests would fail locally because the `spring-cloud-aws` library could not initialize without an access key.
- Fixed issue where database seeding runner would fail because of name collision in JPA mapping.

Closes #178

# How to Test
- Pull code locally and confirm that the `WebApplicationTests.contextLoads()` JUnit test runs successfully.
- Confirm that no JUnit tests were affected in the `dev-managed` profile by checking the bot comment below.

# Comments