### PR TITLE
Switch to slim JRE/JDK images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.14.1-jdk-bullseye
+FROM openjdk:11.0.14.1-jdk-slim-bullseye
 RUN apt-get update
 RUN apt-get install dos2unix -y
 WORKDIR /

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.14.1-jdk-bullseye as build-stage
+FROM openjdk:11.0.14.1-jdk-slim-bullseye as build-stage
 
 RUN mkdir /src
 COPY . /src
@@ -6,7 +6,7 @@ WORKDIR /src
 RUN chmod +x mvnw
 RUN ./mvnw clean package -Dmaven.test.skip=true
 
-FROM openjdk:11.0.14.1-jre-bullseye
+FROM openjdk:11.0.14.1-jre-slim-bullseye
 RUN mkdir /app
 WORKDIR /app
 COPY --from=build-stage /src/target/web-0.0.1-SNAPSHOT.jar /app/web.jar


### PR DESCRIPTION
# Summary
- Changed local development Docker image to use `slim-bullseye` JDK image.
- Changed production intermediary build image to use `slim-bullseye` JDK image.
- Change production final image to use `slim-bullseye` JRE image.

Closes #190

# How to Test
Pull the code locally and verify that the `web` container runs normally.

# Comments
The above changes reduce the size of our Docker images by nearly 50%. This will speed up boot times when developing locally, and also speed up boot times when our Heroku server gets restarted. The slim image also has less tools installed by default, which reduces the attack surface of our app when running in production (this should be reflected in the Snyk check on this PR).