### PR TITLE
LiveReload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,12 @@
 			<artifactId>spring-cloud-starter-aws</artifactId>
 			<version>2.2.6.RELEASE</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<version>2.6.4</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,9 @@ cloud:
       auto: false
     stack:
       auto: false
+devtools:
+  restart:
+    enabled: true
 
 ---
 spring:
@@ -89,6 +92,9 @@ cloud:
 file:
   bucket: ${AWS_BUCKET}
   endpoint: ${AWS_ENDPOINT}
+devtools:
+  restart:
+    enabled: true
 
 ---
 spring:
@@ -139,6 +145,9 @@ file:
 logging:
   file:
     name: /logs/web.log
+devtools:
+  restart:
+    enabled: false
 
 ---
 spring:
@@ -193,3 +202,6 @@ cloud:
 file:
   bucket: ${AWS_BUCKET}
   endpoint: ${AWS_ENDPOINT}
+devtools:
+  restart:
+    enabled: false


### PR DESCRIPTION
# Summary
- Added Spring Boot devtools dependency
- Added configuration to block loading of devtools server in production/GHA.

Closes #131

# How to Test
Pull down the code and start the web server inside Docker Compose. Change a Java file while the server is running. The server should reload and reflect the new changes. Refreshing the page should show these new changes.

# Comments
I skipped the whole garbage with integrating with the browser plugin since I figured nobody wanted to deal with installing and configuring that. Having to manually refresh the page after a change isn't that big of a deal.