### PR TITLE
Fixed dying WebSocket connections

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -32,7 +32,7 @@ http {
             proxy_redirect     off;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Connection "Upgrade";
             proxy_connect_timeout  4000s;
             proxy_read_timeout     4000s;
             proxy_set_header   Host $host;

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -31,9 +31,10 @@ http {
             proxy_pass         http://web;
             proxy_redirect     off;
             proxy_http_version 1.1;
-            proxy_cache_bypass $http_upgrade;
-            proxy_set_header   Upgrade $http_upgrade;
-            proxy_set_header   Connection keep-alive;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout  4000s;
+            proxy_read_timeout     4000s;
             proxy_set_header   Host $host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
# Summary
- Fixed WebSocket connections being prematurely killed by Nginx during local development.

Closes #201

# How to Test
Copy these changes into `proxy/nginx.conf` and restart the Docker Compose stack (you may need to delete the image from Docker Desktop in order to force a rebuild. If you can't find the image use `docker-compose up --build`). Verify that WebSocket connections stay open.

# Comments
Tagging @PlasAJulian for review since he already has the code in place for testing WebSocket connections.

Note that the WebSocket server on the Spring Boot side must be configured to listen on port 80. The JavaScript-side code should use port 443 (or leave off the port and let the browser figure it out).