### PR TITLE
Removed JUnit 4 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,6 @@
 			<version>2.2.6.RELEASE</version>
 		</dependency>
 		<dependency>
-
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-		</dependency>
-		<dependency>
 			<groupId>org.xhtmlrenderer</groupId>
 			<artifactId>flying-saucer-core</artifactId>
 			<version>9.1.6</version>
@@ -176,15 +170,12 @@
 			<artifactId>jtidy</artifactId>
 			<version>r938</version>
 			<scope>compile</scope>
-
 		</dependency>
 		<dependency>
-			
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<version>2.6.4</version>
 			<optional>true</optional>
-
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
# Summary
JUnit 4 accidentally got added in as a dependency. This PR removes it because JUnit 5 is already included through the `org.spring-boot.starter.testing` package.

Closes #211