### PR TITLE
Fixed blocked route to appointment pages

### DIFF
--- a/src/main/java/com/virtudoc/web/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/virtudoc/web/configuration/SecurityConfiguration.java
@@ -34,7 +34,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // The following endpoints do not require authentication.
 
                 .antMatchers("/", "/img/**", "/*.png", "/js/**","/*.ico", "/site.webmanifest", "/forgotMyPassword","/newPassword","/resetEmail",
-                        "/login", "/register", "/HIPAA_consent", "/checkEmail", "/notifications", "/debug/health","/message","/video", "/appointment",
+                        "/login", "/register", "/HIPAA_consent", "/checkEmail", "/notifications", "/debug/health","/message","/video", "/appointment/*",
 
                         "/admin_records","/notifications/delete/{pathvariable:[0-9A-Za-z]+}")
                 .permitAll()

--- a/src/test/java/com/virtudoc/web/E2EWalkthroughTest.java
+++ b/src/test/java/com/virtudoc/web/E2EWalkthroughTest.java
@@ -45,7 +45,7 @@ public class E2EWalkthroughTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "", "/login", "/notifications", "/appointment/show })
+    @ValueSource(strings = { "", "/login", "/notifications", "/appointment/show" })
     public void screenshotPublicPages(String uri) throws IOException {
         driver.get("http://localhost:" + port + uri);
         driver.manage().timeouts().implicitlyWait(1000, TimeUnit.MILLISECONDS);

--- a/src/test/java/com/virtudoc/web/E2EWalkthroughTest.java
+++ b/src/test/java/com/virtudoc/web/E2EWalkthroughTest.java
@@ -45,7 +45,7 @@ public class E2EWalkthroughTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "", "/login", "/notifications" })
+    @ValueSource(strings = { "", "/login", "/notifications", "/appointment/show })
     public void screenshotPublicPages(String uri) throws IOException {
         driver.get("http://localhost:" + port + uri);
         driver.manage().timeouts().implicitlyWait(1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
# Summary
Fixed an issue where access to the appointment sign up page was blocked unless the user was logged in (which is not working at the moment).

# How to Test
- Launch the stack locally.
- `https://localhost/appointment/show` should appear instead of being routed to the login screen.