### PR TITLE
Temporary fix for serialization RCE CVE

### DIFF
--- a/src/main/java/com/virtudoc/web/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/virtudoc/web/controller/GlobalControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.virtudoc.web.controller;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+/**
+ * Temporary mitigation for zero-day RCE vulnerability in a serializer used by Spring Boot in JRE versions > 8.
+ * This class must be in the same package as our controllers.
+ *
+ * @author ARMmaster17
+ */
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class GlobalControllerAdvice {
+    @InitBinder
+    public void setAllowedFields(WebDataBinder dataBinder) {
+        String[] blockedFields = new String[]{"class.*", "Class.*", "*.class.*", "*.Class.*"};
+        dataBinder.setDisallowedFields(blockedFields);
+    }
+}

--- a/src/main/java/com/virtudoc/web/controller/GlobalControllerAdvice.java
+++ b/src/main/java/com/virtudoc/web/controller/GlobalControllerAdvice.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.InitBinder;
 
 /**
- * Temporary mitigation for zero-day RCE vulnerability in a serializer used by Spring Boot in JRE versions > 8.
+ * Temporary mitigation for zero-day RCE vulnerability in a serializer used by Spring Boot in JRE versions 9+.
  * This class must be in the same package as our controllers.
  *
  * @author ARMmaster17


### PR DESCRIPTION
# Summary
A zero-day vulnerability was found in the core serialization library used by Java 9+ that affects Sprint Boot applications. It's an RCE vulnerability, which is bad for us because somebody could remotely run `xmrig` and either use up all of our server credits for the month or get us kicked off of Heroku for a ToS violation (there are crawler bots out there that are doing this with the log4J RCE vulnerability found last year).

This PR implements a temporary fix while the Spring project maintainers roll out a patched version in the coming weeks.

Closes #231

# How to Test
If you wish, the CVE author has a detailed writeup on how to exploit this vulnerability using a simple POJO object and a controller that uses parameter injection: https://www.cyberkendra.com/2022/03/spring4shell-details-and-exploit-code.html This vulnerability should not work with the code on this branch. (Unfortunately, some of the code in in Chinese, but can be translated easily with the Google Translate mobile app and a smartphone with a camera).