### PR TITLE
Reduce Snyk API calls

### DIFF
--- a/.github/workflows/snyk-container-analysis.yml
+++ b/.github/workflows/snyk-container-analysis.yml
@@ -14,11 +14,10 @@
 name: Snyk Container
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
+  schedule:
+    - cron: "0 0 */5 * *"
 
 jobs:
   snyk:


### PR DESCRIPTION
# Summary
I've been getting a lot of emails from Snyk about how we are close to the scan limit imposed on the free tier. This PR reduces the number of calls made to Snyk during GHA runs. Now Snyk scans will only run on PRs and once ever 5 days.

Closes #208

# How to Test
- PR check functionality should be unchanged.