### PR TITLE
Block pages that require an account

### DIFF
--- a/src/main/java/com/virtudoc/web/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/virtudoc/web/configuration/SecurityConfiguration.java
@@ -40,9 +40,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // The following endpoints do not require authentication.
 
                 .antMatchers("/", "/img/**", "/*.png", "/js/**","/*.ico", "/site.webmanifest", "/forgotMyPassword","/newPassword","/resetEmail",
-                        "/login", "/register", "/HIPAA_consent", "/checkEmail", "/notifications", "/debug/health","/message","/video", "/appointment/*",
-                        "/chat/{to}","/message/**","/fetchAllUsers","/app/chat/**","/chat/**",
-                        "/admin_records","/notifications/delete/{pathvariable:[0-9A-Za-z]+}", "/notifications/approve/{pathvariable:[0-9A-Za-z]+}")
+                        "/login", "/register", "/HIPAA_consent", "/checkEmail", "/debug/health", "/app/chat/**","/chat/**")
                 .permitAll()
                 .anyRequest()
                 .authenticated()


### PR DESCRIPTION
# Summary
Right now if you are not logged in and try to do stuff on the site you get a generic error page, which isn't very helpful. 99% of the time this is because you are not logged in. This PR makes it so that when you try to go to a restricted page you are redirected to the login page. This will help remove some confusion when debugging.

#255