### PR TITLE
Fixed malformed S3 configuration

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -202,7 +202,8 @@ cloud:
       access-key: ${AWS_ACCESS_KEY_ID}
       secret-key: ${AWS_SECRET_ACCESS_KEY}
     region:
-      auto: true
+      auto: false
+      static: us-west-2
     s3:
       endpoint: ${AWS_ENDPOINT}
     stack:


### PR DESCRIPTION
## Summary

The AWS 3rd party library was set up to automatically configure the region to use for file storage. When I originally set this up, the documentation led me to believe that it could perform some kind of lookup with the AWS API to find the region for our assigned bucket. What actually happens is that if `auto: true` is set, it tries to guess the region from where the app is currently running. Since Heroku containers run on AWS in `us-east-1`. it was attempting to use that region to talk to our S3 buckets, which are in `us-west-2`. This PR overrides that change.

Closes #265

## How to Test
Unfortunately, as this is a DevOps-related issue, this can only be tested in production. Once this PR is merged and deployed, you can attempt to create a file by creating an appointment.

PR checks below will perform regression testing to ensure that existing configuration did not break, but it is impossible to test the production profile until it is deployed.